### PR TITLE
Migrate character sheet hooks to Dragonbane AppV2

### DIFF
--- a/module.json
+++ b/module.json
@@ -29,8 +29,10 @@
     "systems": [
       {
         "id": "dragonbane",
-        "type": "optional",
-        "compatibility": {}
+        "type": "system",
+        "compatibility": {
+          "minimum": "3.0.3"
+        }
       }
     ],
     "modules": [

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,4 @@
-// Foundry VTT hook registrations
+// Foundry VTT hook registrations for BaneLands module
 
 import type { ConsumableId } from './types/banelands-types';
 
@@ -11,33 +11,26 @@ export function registerHooks(): void {
       const consumableManager = game.banelands?.consumables;
       if (consumableManager) {
         await consumableManager.initializeActorConsumables(actor);
-        // Consumables initialized for new character
       }
     }
   });
 
-  // Pre-create actor hook - for Dragonbane integration
-  Hooks.on('preCreateActor', (_actor: Actor) => {
-    // Future: Add any pre-creation modifications needed for Dragonbane integration
-    if (game.system.id === 'dragonbane') {
-      // Pre-creation setup for Dragonbane character
-    }
-  });
-
-  // Render actor sheet hook - add consumable controls
+  // Render Dragonbane character sheet hook (AppV2) - add consumable controls
   Hooks.on(
-    'renderActorSheet',
-    (app: { actor: Actor; render(): void }, html: JQuery<HTMLElement>) => {
+    'renderDoDCharacterSheet',
+    (
+      app: { actor: Actor; render(): void },
+      element: HTMLElement,
+      _context: unknown,
+      _options: unknown
+    ) => {
       if (app.actor.type !== 'character') return;
-
-      // Add consumable display to character sheets
-      addConsumableDisplay(app, html);
+      addConsumableDisplay(app, element);
     }
   );
 
   // Pre-update actor hook - handle consumable changes
   Hooks.on('preUpdateActor', (actor: Actor, updateData: Record<string, unknown>) => {
-    // Future: Add validation or automatic updates for consumable changes
     const flags = updateData.flags as Record<string, unknown> | undefined;
     if (flags?.banelands) {
       // Consumables updated for actor
@@ -46,45 +39,21 @@ export function registerHooks(): void {
 }
 
 /**
- * Add consumable display to actor sheets
+ * Add consumable display to Dragonbane character sheets (AppV2 native DOM)
  */
-function addConsumableDisplay(
-  app: { actor: Actor; render(): void },
-  html: JQuery<HTMLElement>
-): void {
+function addConsumableDisplay(app: { actor: Actor; render(): void }, element: HTMLElement): void {
   const actor = app.actor;
   const consumableManager = game.banelands?.consumables;
 
   if (!consumableManager) return;
 
-  // Find a good place to insert consumables (this will vary by system)
-  let insertTarget: Element | null = null;
+  // Find the inventory tab using Dragonbane AppV2 selectors
+  const inventoryTab = element.querySelector('.tab[data-group="primary"][data-tab="inventory"]');
+  if (!inventoryTab) return;
 
-  // Try to find system-specific insertion points
-  if (game.system.id === 'dragonbane') {
-    // Look for Dragonbane inventory tab, specifically after the currency section
-    const inventoryTab = html.find('.sheet-body .tab[data-tab="inventory"]')[0];
-    if (inventoryTab) {
-      // Try to find currency section to insert after
-      const currencySection = html.find('.currency, .money, [data-group="currency"]').last()[0];
-      insertTarget = currencySection || inventoryTab;
-    }
-
-    // Fallback to main tab if inventory not found
-    if (!insertTarget) {
-      insertTarget =
-        html.find('.sheet-body .tab[data-tab="main"]')[0] || html.find('.sheet-body')[0] || null;
-    }
-  } else {
-    // Generic fallback - try inventory first, then main
-    insertTarget =
-      html.find('.tab[data-tab="inventory"]')[0] ||
-      html.find('.sheet-body')[0] ||
-      html.find('.window-content')[0] ||
-      null;
-  }
-
-  if (!insertTarget) return;
+  // Find the currency derived-stat-box to insert after
+  const currencyBox = inventoryTab.querySelector('.derived-stat-box');
+  if (!currencyBox) return;
 
   // Get consumable data
   const consumables = consumableManager.getConsumableDisplay(actor);
@@ -101,10 +70,10 @@ function addConsumableDisplay(
             <td>
               <select class="resource-die-select" data-consumable="${consumable.type}">
                 <option value="" ${consumable.depleted ? 'selected' : ''}>—</option>
-                <option value="d6" ${!consumable.depleted && consumable.die === 'D6' ? 'selected' : ''}>⬛ D6</option>
-                <option value="d8" ${!consumable.depleted && consumable.die === 'D8' ? 'selected' : ''}>◆ D8</option>
-                <option value="d10" ${!consumable.depleted && consumable.die === 'D10' ? 'selected' : ''}>🔸 D10</option>
-                <option value="d12" ${!consumable.depleted && consumable.die === 'D12' ? 'selected' : ''}>🔹 D12</option>
+                <option value="d6" ${!consumable.depleted && consumable.die === 'D6' ? 'selected' : ''}>D6</option>
+                <option value="d8" ${!consumable.depleted && consumable.die === 'D8' ? 'selected' : ''}>D8</option>
+                <option value="d10" ${!consumable.depleted && consumable.die === 'D10' ? 'selected' : ''}>D10</option>
+                <option value="d12" ${!consumable.depleted && consumable.die === 'D12' ? 'selected' : ''}>D12</option>
               </select>
             </td>
           </tr>
@@ -115,57 +84,53 @@ function addConsumableDisplay(
     </div>
   `;
 
-  // Insert the HTML - after currency section if found, otherwise at end of container
-  const isCurrencySection =
-    insertTarget.classList?.contains('currency') ||
-    insertTarget.classList?.contains('money') ||
-    insertTarget.hasAttribute?.('data-group');
+  // Insert after the currency derived-stat-box
+  currencyBox.insertAdjacentHTML('afterend', consumablesHtml);
 
-  if (isCurrencySection) {
-    insertTarget.insertAdjacentHTML('afterend', consumablesHtml);
-  } else {
-    insertTarget.insertAdjacentHTML('beforeend', consumablesHtml);
-  }
+  // Add event listeners for rolling resource dice (native DOM)
+  const rollButtons = element.querySelectorAll<HTMLElement>('.roll-resource-die');
+  rollButtons.forEach(button => {
+    button.addEventListener('click', async event => {
+      event.preventDefault();
+      const target = event.currentTarget as HTMLElement;
+      const consumableType = target.dataset.consumable;
 
-  // Add event listeners for rolling resource dice (clicking the labels)
-  html.find('.roll-resource-die').on('click', async event => {
-    event.preventDefault();
-    const $target = $(event.currentTarget);
-    const consumableType = $target.data('consumable');
+      // Don't roll if the resource is depleted
+      if (target.closest('tr')?.classList.contains('depleted')) {
+        return;
+      }
 
-    // Don't roll if the resource is depleted
-    if ($target.closest('tr').hasClass('depleted')) {
-      return;
-    }
-
-    if (consumableType && consumableManager) {
-      await consumableManager.useConsumable(actor, consumableType as ConsumableId);
-      app.render(); // Re-render the sheet to update display
-    }
+      if (consumableType && consumableManager) {
+        await consumableManager.useConsumable(actor, consumableType as ConsumableId);
+        app.render();
+      }
+    });
   });
 
-  // Add event listeners for manual die type changes
-  html.find('.resource-die-select').on('change', async event => {
-    const $target = $(event.currentTarget);
-    const consumableType = $target.data('consumable');
-    const newDieType = $target.val() as string;
+  // Add event listeners for manual die type changes (native DOM)
+  const selects = element.querySelectorAll<HTMLSelectElement>('.resource-die-select');
+  selects.forEach(select => {
+    select.addEventListener('change', async event => {
+      const target = event.currentTarget as HTMLSelectElement;
+      const consumableType = target.dataset.consumable;
+      const newDieType = target.value;
 
-    if (consumableType && consumableManager) {
-      if (newDieType === '' || newDieType === '—') {
-        // Set as depleted
-        const consumables = consumableManager.getActorConsumables(actor);
-        consumables[consumableType as ConsumableId].depleted = true;
-        await consumableManager.setActorConsumables(actor, consumables);
-      } else {
-        // Set the new die type
-        await consumableManager.setResourceDie(
-          actor,
-          consumableType as ConsumableId,
-          newDieType as any
-        );
+      if (consumableType && consumableManager) {
+        if (newDieType === '' || newDieType === '—') {
+          // Set as depleted
+          const consumables = consumableManager.getActorConsumables(actor);
+          consumables[consumableType as ConsumableId].depleted = true;
+          await consumableManager.setActorConsumables(actor, consumables);
+        } else {
+          await consumableManager.setResourceDie(
+            actor,
+            consumableType as ConsumableId,
+            newDieType as any
+          );
+        }
+        app.render();
       }
-      app.render(); // Re-render the sheet to update display
-    }
+    });
   });
 }
 

--- a/src/types/foundry-extensions.d.ts
+++ b/src/types/foundry-extensions.d.ts
@@ -69,13 +69,7 @@ declare global {
 
   interface Window {
     BaneLands?: typeof game.banelands;
-    $: unknown;
-    jQuery: unknown;
   }
-
-  // Global test environment variables
-  const $: unknown;
-  const jQuery: unknown;
 
   // Make global variables available to tests
   var game: Game;
@@ -85,8 +79,6 @@ declare global {
 
   // Extend global object for test environment
   interface Global {
-    $: unknown;
-    jQuery: unknown;
     game: Game;
     ui: UI;
     Hooks: HooksManager;

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { registerHooks } from '../src/hooks';
+
+describe('registerHooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should register a renderDoDCharacterSheet hook (not renderActorSheet)', () => {
+    registerHooks();
+
+    const hookCalls = vi.mocked(Hooks.on).mock.calls;
+    const hookNames = hookCalls.map(call => call[0]);
+
+    expect(hookNames).toContain('renderDoDCharacterSheet');
+    expect(hookNames).not.toContain('renderActorSheet');
+  });
+
+  it('should register createActor and preUpdateActor hooks', () => {
+    registerHooks();
+
+    const hookCalls = vi.mocked(Hooks.on).mock.calls;
+    const hookNames = hookCalls.map(call => call[0]);
+
+    expect(hookNames).toContain('createActor');
+    expect(hookNames).toContain('preUpdateActor');
+  });
+});
+
+describe('addConsumableDisplay (via renderDoDCharacterSheet hook)', () => {
+  let hookCallback: (app: any, element: HTMLElement, context: any, options: any) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Set up mock consumable manager
+    game.banelands = {
+      consumables: {
+        getConsumableDisplay: vi.fn(() => [
+          { type: 'food', name: 'Food', die: 'D8', depleted: false },
+          { type: 'water', name: 'Water', die: 'D6', depleted: false },
+          { type: 'arrows', name: 'Arrows', die: null, depleted: true },
+          { type: 'torches', name: 'Torches', die: 'D12', depleted: false },
+        ]),
+        useConsumable: vi.fn(),
+        setResourceDie: vi.fn(),
+        getActorConsumables: vi.fn(() => ({
+          arrows: { type: 'd6', depleted: true },
+        })),
+        setActorConsumables: vi.fn(),
+        initializeActorConsumables: vi.fn(),
+      } as any,
+      journeys: null,
+      resourceDice: {} as any,
+      api: {} as any,
+    };
+
+    registerHooks();
+
+    // Extract the renderDoDCharacterSheet callback
+    const hookCalls = vi.mocked(Hooks.on).mock.calls;
+    const renderCall = hookCalls.find(call => call[0] === 'renderDoDCharacterSheet');
+    expect(renderCall).toBeDefined();
+    hookCallback = renderCall![1] as any;
+  });
+
+  function createMockSheetElement(): HTMLElement {
+    // Build the mock DOM structure using DOM API
+    const container = document.createElement('div');
+    const tab = document.createElement('div');
+    tab.classList.add('tab');
+    tab.dataset.group = 'primary';
+    tab.dataset.tab = 'inventory';
+
+    const statBox = document.createElement('div');
+    statBox.classList.add('derived-stat-box');
+
+    const table = document.createElement('table');
+    table.classList.add('derived-stat');
+    const row = document.createElement('tr');
+    const th = document.createElement('th');
+    th.textContent = 'Gold';
+    const td = document.createElement('td');
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.value = '10';
+    td.appendChild(input);
+    row.appendChild(th);
+    row.appendChild(td);
+    table.appendChild(row);
+    statBox.appendChild(table);
+    tab.appendChild(statBox);
+    container.appendChild(tab);
+
+    return container;
+  }
+
+  function createMockApp(type = 'character') {
+    return {
+      actor: {
+        id: 'test-actor',
+        name: 'Test Character',
+        type,
+        getFlag: vi.fn(),
+        setFlag: vi.fn(),
+        system: {},
+      },
+      render: vi.fn(),
+    };
+  }
+
+  it('should insert consumables HTML after the currency derived-stat-box', () => {
+    const element = createMockSheetElement();
+    const app = createMockApp();
+
+    hookCallback(app, element, {}, {});
+
+    // Should have two derived-stat-box elements now (currency + consumables)
+    const statBoxes = element.querySelectorAll('.derived-stat-box');
+    expect(statBoxes.length).toBe(2);
+
+    // The second one should be our consumables box
+    const consumablesBox = statBoxes[1]!;
+    expect(consumablesBox.querySelector('.roll-resource-die')).toBeTruthy();
+    expect(consumablesBox.querySelectorAll('.resource-die-select').length).toBe(4);
+  });
+
+  it('should skip non-character actors', () => {
+    const element = createMockSheetElement();
+    const app = createMockApp('monster');
+
+    hookCallback(app, element, {}, {});
+
+    // Should still have only one derived-stat-box
+    const statBoxes = element.querySelectorAll('.derived-stat-box');
+    expect(statBoxes.length).toBe(1);
+  });
+
+  it('should mark depleted resources with depleted class', () => {
+    const element = createMockSheetElement();
+    const app = createMockApp();
+
+    hookCallback(app, element, {}, {});
+
+    const consumablesBox = element.querySelectorAll('.derived-stat-box')[1]!;
+    const rows = consumablesBox.querySelectorAll('tr');
+    const depletedRows = consumablesBox.querySelectorAll('tr.depleted');
+
+    expect(rows.length).toBe(4);
+    expect(depletedRows.length).toBe(1); // arrows is depleted
+  });
+
+  it('should add click handlers on .roll-resource-die elements', async () => {
+    const element = createMockSheetElement();
+    const app = createMockApp();
+
+    hookCallback(app, element, {}, {});
+
+    // Click a non-depleted resource die label
+    const foodDieLabel = element.querySelector(
+      '.roll-resource-die[data-consumable="food"]'
+    ) as HTMLElement;
+    expect(foodDieLabel).toBeTruthy();
+
+    foodDieLabel.click();
+
+    // Wait for async handler
+    await vi.waitFor(() => {
+      expect(game.banelands!.consumables.useConsumable).toHaveBeenCalledWith(app.actor, 'food');
+    });
+  });
+
+  it('should not roll depleted resources on click', async () => {
+    const element = createMockSheetElement();
+    const app = createMockApp();
+
+    hookCallback(app, element, {}, {});
+
+    // Click the depleted resource die label (arrows)
+    const arrowsDieLabel = element.querySelector(
+      '.roll-resource-die[data-consumable="arrows"]'
+    ) as HTMLElement;
+    expect(arrowsDieLabel).toBeTruthy();
+
+    arrowsDieLabel.click();
+
+    // Give async handler time to potentially run
+    await new Promise(r => setTimeout(r, 10));
+    expect(game.banelands!.consumables.useConsumable).not.toHaveBeenCalled();
+  });
+
+  it('should add change handlers on .resource-die-select elements', async () => {
+    const element = createMockSheetElement();
+    const app = createMockApp();
+
+    hookCallback(app, element, {}, {});
+
+    // Change a resource die select
+    const foodSelect = element.querySelector(
+      '.resource-die-select[data-consumable="food"]'
+    ) as HTMLSelectElement;
+    expect(foodSelect).toBeTruthy();
+
+    foodSelect.value = 'd10';
+    foodSelect.dispatchEvent(new Event('change'));
+
+    await vi.waitFor(() => {
+      expect(game.banelands!.consumables.setResourceDie).toHaveBeenCalledWith(
+        app.actor,
+        'food',
+        'd10'
+      );
+    });
+  });
+
+  it('should use native DOM APIs, not jQuery', () => {
+    // Verified by working with plain HTMLElement (not jQuery object)
+    const element = createMockSheetElement();
+    const app = createMockApp();
+
+    hookCallback(app, element, {}, {});
+
+    const statBoxes = element.querySelectorAll('.derived-stat-box');
+    expect(statBoxes.length).toBe(2);
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,31 +1,5 @@
 // Import types for test environment
 
-// Mock jQuery
-const mockJQuery = () => ({
-  find: vi.fn().mockReturnThis(),
-  on: vi.fn().mockReturnThis(),
-  off: vi.fn().mockReturnThis(),
-  html: vi.fn().mockReturnThis(),
-  append: vi.fn().mockReturnThis(),
-  remove: vi.fn().mockReturnThis(),
-  addClass: vi.fn().mockReturnThis(),
-  removeClass: vi.fn().mockReturnThis(),
-  hasClass: vi.fn(() => false),
-  attr: vi.fn().mockReturnThis(),
-  data: vi.fn().mockReturnThis(),
-  val: vi.fn().mockReturnThis(),
-  text: vi.fn().mockReturnThis(),
-  each: vi.fn().mockReturnThis(),
-  length: 0,
-  get: vi.fn(() => undefined),
-  [Symbol.iterator]: function* () {
-    // Make it iterable
-  },
-});
-
-global.$ = vi.fn(mockJQuery);
-global.jQuery = global.$;
-
 // Mock Foundry globals
 global.game = {
   user: {


### PR DESCRIPTION
## Summary

- Migrates from legacy `renderActorSheet` hook to AppV2 `renderDoDCharacterSheet` hook, fixing broken consumable UI on Dragonbane 3.0.3+ character sheets
- Replaces all jQuery DOM operations with native DOM API (`querySelector`, `addEventListener`, `dataset`, `classList`)
- Removes generic/multi-system fallback selectors — this is a Dragonbane-only module
- Adds Dragonbane 3.0.3 minimum version requirement in `module.json`

## Test plan

- [ ] `npm run validate` passes (lint, format, typecheck, tests, build)
- [ ] 9 new hooks tests cover hook registration, DOM insertion, click/change handlers, and depleted resource behavior
- [ ] Manual test: open a Dragonbane character sheet in Foundry, verify consumables appear in inventory tab after currency section
- [ ] Manual test: click-to-roll and dropdown-to-change-die still work

🤖 Generated with [Claude Code](https://claude.ai/code)